### PR TITLE
Add verification of the presence of a message

### DIFF
--- a/src/EstCeQueCestBientot/Service/MessageService.php
+++ b/src/EstCeQueCestBientot/Service/MessageService.php
@@ -68,6 +68,10 @@ class MessageService
                 break;
             }
         }
+        
+        if (empty($message)) {
+            throw new MessageNotFoundException();
+        }
 
         return $message;
     }


### PR DESCRIPTION
If a message wasn't present in configuration file for specified time range a twig error was thrown (because $message was not an object).
So this modification able to load default message by throw a MessageNotFoundException.
